### PR TITLE
Fixes for unicode replacement and a couple of Issues

### DIFF
--- a/grammars/tts_lua.cson
+++ b/grammars/tts_lua.cson
@@ -1,14 +1,10 @@
 # Adapted from https://github.com/FireZenk/language-lua
 'comment': 'Lua Syntax: version 0.8'
 'fileTypes': [
-  'lua'
-  'nse'
-  'rockspec'
-  'luacheckrc'
-  'lakefile'
+  'ttslua'
 ]
 'firstLineMatch': '\\A#!.*?\\blua\\b'
-'name': 'Lua'
+'name': 'TTSLua'
 'patterns': [
   {
     'captures':

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -75,7 +75,7 @@ class FileHandler
     if atom.config.get('tabletopsimulator-lua.convertUnicodeCharacters')
       replace_unicode = (unicode) ->
         unicode.replace(String.fromCharCode(parseInt(unicode.match[1],16)))
-      editor.scan(/\\u\{([a-zA-Z0-9]{1,4})\}/, replace_unicode)
+      editor.scan(/\\u\{([a-zA-Z0-9]{1,4})\}/g, replace_unicode)
 
     # Restore cursor position
     try

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -287,7 +287,7 @@ module.exports = TabletopsimulatorLua =
         for f,i in @data.scriptStates
           @file = new FileHandler()
           f.name = f.name.replace(/([":<>/\\|?*])/g, "")
-          @file.setBasename(f.name + "." + f.guid + ".lua")
+          @file.setBasename(f.name + "." + f.guid + ".ttslua")
           @file.setDatasize(f.script.length)
           @file.create()
 
@@ -339,7 +339,7 @@ module.exports = TabletopsimulatorLua =
             for f,i in @data.scriptStates
               @file = new FileHandler()
               f.name = f.name.replace(/([":<>/\\|?*])/g, "")
-              @file.setBasename(f.name + "." + f.guid + ".lua")
+              @file.setBasename(f.name + "." + f.guid + ".ttslua")
               @file.setDatasize(f.script.length)
               @file.create()
 
@@ -373,7 +373,7 @@ module.exports = TabletopsimulatorLua =
             for f,i in @data.scriptStates
               @file = new FileHandler()
               f.name = f.name.replace(/([":<>/\\|?*])/g, "")
-              @file.setBasename(f.name + "." + f.guid + ".lua")
+              @file.setBasename(f.name + "." + f.guid + ".ttslua")
               @file.setDatasize(f.script.length)
               @file.create()
 

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -245,7 +245,7 @@ module.exports = TabletopsimulatorLua =
         if atom.config.get('tabletopsimulator-lua.convertUnicodeCharacters')
           replace_character = (character) ->
             return "\\u{" + character.codePointAt(0).toString(16) + "}"
-          @luaObject.script = @luaObject.script.replace(/[\u0080-\u00FF]/g, replace_character)
+          @luaObject.script = @luaObject.script.replace(/[\u0080-\uFFFF]/g, replace_character)
         @luaObjects.scriptStates.push(@luaObject)
 
     if not @if_connected


### PR DESCRIPTION
Unicode replacement wasn't handling full range of utf-8 and wasn't handling more than one utf-8 character per line.  Fixed.

Change our temp files from .lua to .ttslua - this will stop the package being applied to non TTS Lua files.

fixes #17
fixes #5

Since we only ever operate on the temp files we make ourselves, this shouldn't have any knock-on issues with third party mods (I mean utility mods, not TTS games), at least to the best of my understanding.  Doing this means that the scope source.tts.lua will only apply to our files, and the generic scope of source.lua can be handled by another package.