### PR TITLE
New Atom commands, issue #25, some experimental things

### DIFF
--- a/keymaps/tabletopsimulator-lua.cson
+++ b/keymaps/tabletopsimulator-lua.cson
@@ -19,3 +19,4 @@
   'ctrl-alt-<': 'tabletopsimulator-lua:selectFunction'
   'ctrl-alt->': 'tabletopsimulator-lua:retractSelection'
   'ctrl-?':     'tabletopsimulator-lua:toggleSelectionCursor'
+  'ctrl-i':     'tabletopsimulator-lua:displayCurrentFunction'

--- a/keymaps/tabletopsimulator-lua.cson
+++ b/keymaps/tabletopsimulator-lua.cson
@@ -18,3 +18,4 @@
   'ctrl->':     'tabletopsimulator-lua:retractSelection'
   'ctrl-alt-<': 'tabletopsimulator-lua:selectFunction'
   'ctrl-alt->': 'tabletopsimulator-lua:retractSelection'
+  'ctrl-?':     'tabletopsimulator-lua:toggleSelectionCursor'

--- a/keymaps/tabletopsimulator-lua.cson
+++ b/keymaps/tabletopsimulator-lua.cson
@@ -13,7 +13,8 @@
 #'atom-text-editor':
 
 'atom-workspace atom-text-editor:not([mini])':
-  'ctrl-g': 'tabletopsimulator-lua:gotoFunction'
-  'ctrl-?': 'tabletopsimulator-lua:selectFunction'
-  'ctrl-<': 'tabletopsimulator-lua:expandSelection'
-  'ctrl->': 'tabletopsimulator-lua:retractSelection'
+  'ctrl-g':     'tabletopsimulator-lua:gotoFunction'
+  'ctrl-<':     'tabletopsimulator-lua:expandSelection'
+  'ctrl->':     'tabletopsimulator-lua:retractSelection'
+  'ctrl-alt-<': 'tabletopsimulator-lua:selectFunction'
+  'ctrl-alt->': 'tabletopsimulator-lua:retractSelection'

--- a/keymaps/tabletopsimulator-lua.cson
+++ b/keymaps/tabletopsimulator-lua.cson
@@ -13,10 +13,11 @@
 #'atom-text-editor':
 
 'atom-workspace atom-text-editor:not([mini])':
-  'ctrl-g':     'tabletopsimulator-lua:gotoFunction'
-  'ctrl-<':     'tabletopsimulator-lua:expandSelection'
-  'ctrl->':     'tabletopsimulator-lua:retractSelection'
-  'ctrl-alt-<': 'tabletopsimulator-lua:selectFunction'
-  'ctrl-alt->': 'tabletopsimulator-lua:retractSelection'
-  'ctrl-?':     'tabletopsimulator-lua:toggleSelectionCursor'
-  'ctrl-i':     'tabletopsimulator-lua:displayCurrentFunction'
+  'ctrl-g':           'tabletopsimulator-lua:gotoFunction'
+  'ctrl-<':           'tabletopsimulator-lua:expandSelection'
+  'ctrl->':           'tabletopsimulator-lua:retractSelection'
+  'ctrl-alt-<':       'tabletopsimulator-lua:selectFunction'
+  'ctrl-alt->':       'tabletopsimulator-lua:retractSelection'
+  'ctrl-?':           'tabletopsimulator-lua:toggleSelectionCursor'
+  'ctrl-i':           'tabletopsimulator-lua:displayCurrentFunction'
+	'ctrl-alt-shift-g': 'go-to-line:toggle'

--- a/keymaps/tabletopsimulator-lua.cson
+++ b/keymaps/tabletopsimulator-lua.cson
@@ -14,6 +14,7 @@
 
 'atom-workspace atom-text-editor:not([mini])':
   'ctrl-g':           'tabletopsimulator-lua:gotoFunction'
+  'ctrl-shift-g':     'tabletopsimulator-lua:jumpToFunction'
   'ctrl-<':           'tabletopsimulator-lua:expandSelection'
   'ctrl->':           'tabletopsimulator-lua:retractSelection'
   'ctrl-alt-<':       'tabletopsimulator-lua:selectFunction'

--- a/keymaps/tabletopsimulator-lua.cson
+++ b/keymaps/tabletopsimulator-lua.cson
@@ -9,3 +9,7 @@
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
 #'atom-workspace':
 #  'ctrl-alt-o': 'tabletopsimulator-lua:toggle'
+
+'atom-text-editor':
+  'ctrl-g':       'tabletopsimulator-lua:gotoFunction'
+  'ctrl-shift-/': 'tabletopsimulator-lua:selectFunction'

--- a/keymaps/tabletopsimulator-lua.cson
+++ b/keymaps/tabletopsimulator-lua.cson
@@ -10,8 +10,10 @@
 #'atom-workspace':
 #  'ctrl-alt-o': 'tabletopsimulator-lua:toggle'
 
-'atom-text-editor':
-  'ctrl-g':       'tabletopsimulator-lua:gotoFunction'
-  'ctrl-shift-/': 'tabletopsimulator-lua:selectFunction'
-  'ctrl-shift-,': 'tabletopsimulator-lua:expandSelection'
-  'ctrl-shift-.': 'tabletopsimulator-lua:retractSelection'
+#'atom-text-editor':
+
+'atom-workspace atom-text-editor:not([mini])':
+  'ctrl-g': 'tabletopsimulator-lua:gotoFunction'
+  'ctrl-?': 'tabletopsimulator-lua:selectFunction'
+  'ctrl-<': 'tabletopsimulator-lua:expandSelection'
+  'ctrl->': 'tabletopsimulator-lua:retractSelection'

--- a/keymaps/tabletopsimulator-lua.cson
+++ b/keymaps/tabletopsimulator-lua.cson
@@ -13,3 +13,5 @@
 'atom-text-editor':
   'ctrl-g':       'tabletopsimulator-lua:gotoFunction'
   'ctrl-shift-/': 'tabletopsimulator-lua:selectFunction'
+  'ctrl-shift-,': 'tabletopsimulator-lua:expandSelection'
+  'ctrl-shift-.': 'tabletopsimulator-lua:retractSelection'

--- a/keymaps/tabletopsimulator-lua.cson
+++ b/keymaps/tabletopsimulator-lua.cson
@@ -20,4 +20,3 @@
   'ctrl-alt->':       'tabletopsimulator-lua:retractSelection'
   'ctrl-?':           'tabletopsimulator-lua:toggleSelectionCursor'
   'ctrl-i':           'tabletopsimulator-lua:displayCurrentFunction'
-	'ctrl-alt-shift-g': 'go-to-line:toggle'

--- a/lib/function-list-view.coffee
+++ b/lib/function-list-view.coffee
@@ -95,10 +95,11 @@ class FunctionListView extends SelectListView
     @subscriptions = null
     @detach()
 
-  toggle: ->
+  toggle: (searchText = '') ->
     if @panel?.isVisible()
       @panel?.show()
     else
       @storeFocusedElement()
+      @filterEditorView.setText(searchText)
       @panel.show()
       @focusFilterEditor()

--- a/lib/function-list-view.coffee
+++ b/lib/function-list-view.coffee
@@ -68,14 +68,17 @@ class FunctionListView extends SelectListView
         row = parseInt(m[2])-1
         currentFile = @editor.getPath()
         currentRow = 0
+        offset = 0
         if @expandedLineNumbers
           for filepath, lineNumbers of @expandedLineNumbers
             if filepath != currentFile and lineNumbers.startRow > currentRow and
                row >= lineNumbers.startRow and row < lineNumbers.endRow
               currentRow = lineNumbers.startRow
               currentFile = filepath
+            else if lineNumbers.endRow < row
+              offset += (lineNumbers.endRow - lineNumbers.startRow) + 1
         if currentFile != @editor.getPath()
-          row -= currentRow
+          row -= (currentRow + offset)
           atom.workspace.open(currentFile, {initialLine: row, initialColumn: 0}).then (editor) ->
             editor.setCursorBufferPosition([row, 0])
             editor.scrollToCursorPosition()

--- a/lib/function-list-view.coffee
+++ b/lib/function-list-view.coffee
@@ -1,0 +1,104 @@
+{$$, View} = require 'space-pen'
+{SelectListView} = require 'atom-space-pen-views'
+{BufferedProcess, CompositeDisposable} = require 'atom'
+
+module.exports =
+class FunctionListView extends SelectListView
+  maxItems: 1000
+  minFilterLength: 3
+
+  initialize: ->
+    super
+    @editor = atom.workspace.getActiveTextEditor()
+    @pane = atom.workspace.paneForItem(@editor)
+    @currentRow = @editor.getCursorBufferPosition().row
+    @panel = atom.workspace.addModalPanel(item: this, visible: false)
+    @showFunctionName = atom.config.get('tabletopsimulator-lua.editor.showFunctionInGoto')
+    @addClass 'tabletopsimulator-lua-goto-function'
+    @addItems()
+
+  addItems: () =>
+    if @editor
+      @lineCount = @editor.getLineCount()
+      if @editor.getPath().endsWith('.ttslua')
+        row = 0
+        functions = []
+        while (row < @lineCount)
+          line = @editor.lineTextForBufferRow(row)
+          m = line.match(/^\s*function\s+([^\s\(]*)\s*[\(]([^\)]*)\)/)
+          if m
+            functions.push({functionName:m[1], parameters:m[2], line:row})
+          row += 1
+        functions.sort (a, b) -> return if a.functionName.toLowerCase() > b.functionName.toLowerCase() then 1 else -1
+        @setItems(functions)
+
+  viewForItem: ({functionName, parameters, line}) ->
+    li = document.createElement('li')
+    addSpan = (classNames, text) ->
+      span = document.createElement('span')
+      for name in classNames
+        span.classList.add(name)
+      span.textContent = text
+      li.appendChild(span)
+    if @showFunctionName
+      addSpan(['syntax--keyword', 'syntax--control', 'syntax--lua'], "function ")
+    addSpan(['syntax--entity', 'syntax--name', 'syntax--function', 'syntax--lua'], functionName)
+    addSpan(['syntax--punctuation', 'syntax--definition', 'syntax--parameters', 'syntax--begin',  'syntax--lua'], '(')
+    addSpan(['syntax--variable', 'syntax--parameter', 'syntax--function', 'syntax--lua'], parameters)
+    addSpan(['syntax--punctuation', 'syntax--definition', 'syntax--parameters', 'syntax--end',  'syntax--lua'], ')')
+    return li
+
+  gotoLine: (line, relative=false) ->
+    if relative
+      line += @currentRow
+    if line < 0
+      line = 0
+    if line >= @lineCount
+      line = @lineCount
+    @editor.setCursorBufferPosition([line, 0])
+    @editor.scrollToCursorPosition()
+
+  getFilterKey: ->
+    return 'functionName'
+
+  getSearchValue: ->
+    return @filterEditorView.getText()
+
+  confirmSelection: ->
+    m = @getSearchValue().match(/^([-+]?)([0-9]+)$/)
+    if m
+      if m[1]
+        @gotoLine(parseInt(m[1]+m[2]), true)
+      else
+        @gotoLine(parseInt(m[2])-1)
+      @cancelled()
+    else
+      item = @getSelectedItem()
+      if item?
+        @confirmed(item)
+      else
+        @cancel()
+
+  confirmed: (item)->
+    if @editor
+      @gotoLine(item.line)
+    @cancelled()
+
+  cancelled: ->
+    @items = []
+    @panel.hide()
+    if @pane
+      @pane.activate()
+
+  destroy: ->
+    @subscriptions?.dispose()
+    @subscriptions = null
+    @detach()
+
+  toggle: ->
+    if @panel?.isVisible()
+      @panel?.show()
+    else
+      @storeFocusedElement()
+      @panel.show()
+      @focusFilterEditor()

--- a/lib/function-list-view.coffee
+++ b/lib/function-list-view.coffee
@@ -68,17 +68,14 @@ class FunctionListView extends SelectListView
         row = parseInt(m[2])-1
         currentFile = @editor.getPath()
         currentRow = 0
-        offset = 0
         if @expandedLineNumbers
           for filepath, lineNumbers of @expandedLineNumbers
             if filepath != currentFile and lineNumbers.startRow > currentRow and
-               row > lineNumbers.startRow and row < lineNumbers.endRow
+               row >= lineNumbers.startRow and row < lineNumbers.endRow
               currentRow = lineNumbers.startRow
               currentFile = filepath
-            else if lineNumbers.endRow < row
-              offset += lineNumbers.endRow - lineNumbers.startRow
         if currentFile != @editor.getPath()
-          row -= (currentRow + offset + 1)
+          row -= currentRow
           atom.workspace.open(currentFile, {initialLine: row, initialColumn: 0}).then (editor) ->
             editor.setCursorBufferPosition([row, 0])
             editor.scrollToCursorPosition()

--- a/lib/function-list-view.coffee
+++ b/lib/function-list-view.coffee
@@ -78,7 +78,7 @@ class FunctionListView extends SelectListView
             else if lineNumbers.endRow < row
               offset += lineNumbers.endRow - lineNumbers.startRow
         if currentFile != @editor.getPath()
-          row -= (currentRow + offset + 1) 
+          row -= (currentRow + offset + 1)
           atom.workspace.open(currentFile, {initialLine: row, initialColumn: 0}).then (editor) ->
             editor.setCursorBufferPosition([row, 0])
             editor.scrollToCursorPosition()
@@ -119,6 +119,7 @@ class FunctionListView extends SelectListView
       @panel?.show()
     else
       #@storeFocusedElement()
-      #@filterEditorView.setText(searchText)
+      @filterEditorView.setText(searchText)
+      @filterEditorView.model.selectAll()
       @panel.show()
       @focusFilterEditor()

--- a/lib/function-list-view.coffee
+++ b/lib/function-list-view.coffee
@@ -4,7 +4,7 @@
 
 module.exports =
 class FunctionListView extends SelectListView
-  maxItems: 1000
+  maxItems: 99999
   minFilterLength: 3
 
   initialize: ->

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -142,6 +142,10 @@ module.exports =
             snippet: '\n\tfunction ' + function_name + "()\n\t\t$1\n\t\treturn 1\n\tend\n\tstartLuaCoroutine(self, '" + function_name + "')\nend"
             displayText: 'function...coroutine...end'
           },
+          {
+            snippet: '\n\tfunction ' + function_name + "()\n\t\trepeat\n\t\t\tcoroutine.yield(0)\n\t\tuntil $1\n\t\treturn 1\n\tend\n\tstartLuaCoroutine(self, '" + function_name + "')\nend"
+            displayText: 'function...coroutine...repeat...end'
+          },
         ]
 
       # Section: Global object

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -27,8 +27,8 @@ module.exports =
             spacing = ' '
           operator   = matches[3]
           postfix    = matches[5]
-          if postfix != ''
-            postfix += '\n'
+          #if postfix != ''
+          #  postfix += '\n'
           resolve([{
             snippet: spacing + '=' + spacing + identifier + spacing + operator + spacing + postfix + '$1'
             displayText: '=' + spacing + identifier + spacing + operator + spacing + postfix

--- a/lib/status-bar-function-view.coffee
+++ b/lib/status-bar-function-view.coffee
@@ -80,23 +80,11 @@ class StatusBarFunctionView extends HTMLElement
     row = parseInt(event.target.target)
     if row >= 0
       editor = atom.workspace.getActiveTextEditor()
+      editor.setCursorBufferPosition([row, 0])
       if event.shiftKey
-        startRow = row
-        lastRow = editor.getLastBufferRow()
-        line = editor.lineTextForBufferRow(row)
-        m = line.match(/^(\s*)function/)
-        indent = m[1].length
-        while row <= lastRow
-          line = editor.lineTextForBufferRow(row)
-          m = line.match(/^(\s*)end($|\s|--)/)
-          if m and m[1].length == indent
-            editor.setCursorBufferPosition([row, editor.lineTextForBufferRow(row).length])
-            editor.selectToBufferPosition([startRow, 0])
-            editor.scrollToCursorPosition()
-            return
-          row += 1
+        editorElement = atom.views.getView(editor)
+        atom.commands.dispatch(editorElement, 'tabletopsimulator-lua:selectFunction')
       else
-        editor.setCursorBufferPosition([row, 0])
         editor.scrollToCursorPosition()
 
 

--- a/lib/status-bar-function-view.coffee
+++ b/lib/status-bar-function-view.coffee
@@ -92,10 +92,12 @@ class StatusBarFunctionView extends HTMLElement
           if m and m[1].length == indent
             editor.setCursorBufferPosition([row, editor.lineTextForBufferRow(row).length])
             editor.selectToBufferPosition([startRow, 0])
+            editor.scrollToCursorPosition()
             return
           row += 1
       else
         editor.setCursorBufferPosition([row, 0])
+        editor.scrollToCursorPosition()
 
 
 module.exports = document.registerElement('status-bar-function', prototype: StatusBarFunctionView.prototype, extends: 'div')

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -492,13 +492,16 @@ module.exports = TabletopsimulatorLua =
     if not editor or not editor.getPath().endsWith('.ttslua')
       return
     [names, rows] = @getFunctions(editor, editor.getCursorBufferPosition().row)
-    output = '`'
-    for name, i in names
-      if i > 0
-        output += ' → '
-      output += name
-    output += '`'
-    atom.notifications.addInfo(output, {icon: 'type-function'})
+    if names == null
+      atom.notifications.addInfo("Not in a function!", {icon: 'type-function'})
+    else
+      output = '`'
+      for name, i in names
+        if i > 0
+          output += ' → '
+        output += name
+      output += '`'
+      atom.notifications.addInfo(output, {icon: 'type-function'})
 
   gotoFunction: ->
     editor = atom.workspace.getActiveTextEditor()

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -27,6 +27,12 @@ clientport = 39999
 serverport = 39998
 
 ttsLuaDir = path.join(os.tmpdir(), "TabletopSimulator", "Tabletop Simulator Lua")
+# remove old name for temp dir, for people who have used previous versions (21/08/17)
+# TODO remove this at some later date
+try
+  atom.project.removePath(path.join(os.tmpdir(), "TabletopSimulator", "Lua"))
+catch error
+
 
 # Check atom version; if 1.19+ then editor.save has become async
 # TODO when 1.19 has been out long enough remove this check and require atom 1.19 in package.json
@@ -541,13 +547,7 @@ module.exports = TabletopsimulatorLua =
               fs.unlinkSync(@deletefile)
           catch error
 
-          # remove old name for temp dir, for people who have used previous versions (21/08/17)
-          # TODO remove this at some later date
-          oldttsLuaDir = path.join(os.tmpdir(), "TabletopSimulator", "Lua")
-          try
-            atom.project.removePath(oldttsLuaDir)
-          catch error
-          # Add temp dir to atom 
+          # Add temp dir to atom
           atom.project.addPath(ttsLuaDir)
 
           if not TabletopsimulatorLua.if_connected

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -486,8 +486,12 @@ module.exports = TabletopsimulatorLua =
 
 
   gotoFunction: ->
-    @functionListView = new FunctionListView().toggle()
-
+    editor = atom.workspace.getActiveTextEditor()
+    text = editor.getSelectedText()
+    if text.match(/^\w+$/)
+      @functionListView = new FunctionListView().toggle(text)
+    else
+      @functionListView = new FunctionListView().toggle()
 
   selectCurrentFunction: ->
     editor = atom.workspace.getActiveTextEditor()

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -510,6 +510,7 @@ module.exports = TabletopsimulatorLua =
       m = line.match(re)
       if m
         editor.setCursorBufferPosition([row, 0])
+        editor.scrollToCursorPosition()
         return
       row += 1
     # If we didn't find it then open Go To Function panel

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -546,7 +546,7 @@ module.exports = TabletopsimulatorLua =
         line = editor.lineTextForBufferRow(row)
         #m = line.match(/^(\s*)(if[\s\(]|for[\s\(]|while[\s\(]|repeat($|\s|--)|function[\s])/) #strict control blocks
         m = line.match(/^(\s*)([^\s]+)/)
-        if m and m[2] != 'else' and not m[2].startsWith('--')
+        if m and not m[2].match(/^(else|elseif|--.*)/)
           n = editor.lineTextForBufferRow(row+1).match(/^(\s*)([^\s]+)/)
           if n and n[1].length > m[1].length
             @blockSelectIndent = n[1].length
@@ -579,7 +579,7 @@ module.exports = TabletopsimulatorLua =
       line = editor.lineTextForBufferRow(row)
       #m = line.match(/^(\s*)(if[\s\(]|for[\s\(]|while[\s\(]|repeat($|\s|--)|function[\s])/) #strict control blocks
       m = line.match(/^(\s*)([^\s]+)/)
-      if m and m[1].length < @blockSelectIndent and m[2] != 'else' and not m[2].startsWith('--')
+      if m and m[1].length < @blockSelectIndent and not m[2].match(/^(else|elseif|--.*)/)
         @blockSelectTop = row
         @blockSelectIndent = m[1].length
         break
@@ -592,7 +592,7 @@ module.exports = TabletopsimulatorLua =
       line = editor.lineTextForBufferRow(row)
       #m = line.match(/^(\s*)(end($|\s|--)|until[\s\)])/)  #strict control blocks
       m = line.match(/^(\s*)([^\s]+)/)
-      if m and m[1].length <= @blockSelectIndent and m[2] != 'else' and not m[2].startsWith('--')
+      if m and m[1].length <= @blockSelectIndent and not m[2].match(/^(else|elseif|--.*)/)
         @blockSelectBottom = row
         @blockSelectIndent = m[1].length
         break

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -492,12 +492,13 @@ module.exports = TabletopsimulatorLua =
     if not editor or not editor.getPath().endsWith('.ttslua')
       return
     [names, rows] = @getFunctions(editor, editor.getCursorBufferPosition().row)
-    output = ""
+    output = '`'
     for name, i in names
       if i > 0
         output += ' → '
       output += name
-    atom.notifications.addInfo(output)
+    output += '`'
+    atom.notifications.addInfo(output, {icon: 'type-function'})
 
   gotoFunction: ->
     editor = atom.workspace.getActiveTextEditor()

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -251,6 +251,7 @@ module.exports = TabletopsimulatorLua =
     @subscriptions.add atom.commands.add 'atom-workspace', 'tabletopsimulator-lua:expandSelection': => @expandSelection()
     @subscriptions.add atom.commands.add 'atom-workspace', 'tabletopsimulator-lua:retractSelection': => @retractSelection()
     @subscriptions.add atom.commands.add 'atom-workspace', 'tabletopsimulator-lua:toggleSelectionCursor': => @toggleCursorSelectionEnd()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'tabletopsimulator-lua:displayCurrentFunction': => @displayFunction()
 
     # Register events
     @subscriptions.add atom.config.observe 'tabletopsimulator-lua.autocomplete.excludeLowerPriority', (newValue) => @excludeChange()
@@ -486,6 +487,17 @@ module.exports = TabletopsimulatorLua =
     if not @statusBarActive
       @statusBarFunctionView.updateFunction(null)
 
+  displayFunction: ->
+    editor = atom.workspace.getActiveTextEditor()
+    if not editor or not editor.getPath().endsWith('.ttslua')
+      return
+    [names, rows] = @getFunctions(editor, editor.getCursorBufferPosition().row)
+    output = ""
+    for name, i in names
+      if i > 0
+        output += ' → '
+      output += name
+    atom.notifications.addInfo(output)
 
   gotoFunction: ->
     editor = atom.workspace.getActiveTextEditor()

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -697,13 +697,13 @@ module.exports = TabletopsimulatorLua =
       if found
         filepath = completeFilepath(found[2], dir)
         filetext = null
-        #if not fs.existsSync(filepath)
-        #  atom.notifications.addError("Could not catalog #include - file not found:", {icon: 'type-file', detail: filepath})
-        #  continue
-        try
-          filetext = fs.readFileSync(filepath, 'utf8')
-        catch error
-          atom.notifications.addError(error.message, {dismissable: true, icon: 'type-file', detail: filepath})
+        if fs.existsSync(filepath)
+          try
+            filetext = fs.readFileSync(filepath, 'utf8')
+          catch error
+            atom.notifications.addError(error.message, {dismissable: true, icon: 'type-file', detail: filepath})
+        else
+          atom.notifications.addError("Could not catalog #include - file not found:", {icon: 'type-file', detail: filepath})
         if filetext
           if filepath of alreadyInserted
             atom.notifications.addWarning(atom.config.get('tabletopsimulator-lua.loadSave.includeKeyword') + " used for same file twice.", {dismissable: true, icon: 'type-file', detail: filepath})

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -483,6 +483,8 @@ module.exports = TabletopsimulatorLua =
   # TODO refector this to be an optional form of expandSelection
   selectCurrentFunction: ->
     editor = atom.workspace.getActiveTextEditor()
+    if not editor or not editor.getPath().endsWith(".ttslua")
+      return
     pos = editor.getCursorBufferPosition()
     storeCursor = true
     row = pos.row
@@ -523,6 +525,8 @@ module.exports = TabletopsimulatorLua =
 
   expandSelection: ->
     editor = atom.workspace.getActiveTextEditor()
+    if not editor or not editor.getPath().endsWith(".ttslua")
+      return
     cursor = editor.getLastCursor()
     pos = cursor.getBufferPosition()
     if cursor.selection.isEmpty()
@@ -588,6 +592,8 @@ module.exports = TabletopsimulatorLua =
 
   retractSelection: ->
     editor = atom.workspace.getActiveTextEditor()
+    if not editor or not editor.getPath().endsWith(".ttslua")
+      return
     if @blockSelectStack and @blockSelectStack.length > 1
       [@blockSelectTop, @blockSelectBottom, @blockSelectIndent] = @blockSelectStack.pop()
       editor.setSelectedBufferRange([[@blockSelectTop, 0], [@blockSelectBottom, editor.lineTextForBufferRow(@blockSelectBottom).length]])

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -712,6 +712,9 @@ module.exports = TabletopsimulatorLua =
             marker = '----' + found[1]
             newDir = path.dirname(filepath)
             lines[i] = marker + '\n' + @insertFiles(filetext, newDir, alreadyInserted) + '\n' + marker
+        else
+          marker = '----' + found[1]
+          lines[i] = marker + '\n' + marker
     return lines.join('\n')
 
   excludeChange: (newValue) ->

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -246,6 +246,7 @@ module.exports = TabletopsimulatorLua =
     @subscriptions.add atom.commands.add 'atom-workspace', 'tabletopsimulator-lua:getObjects': => @getObjects()
     @subscriptions.add atom.commands.add 'atom-workspace', 'tabletopsimulator-lua:saveAndPlay': => @saveAndPlay()
     @subscriptions.add atom.commands.add 'atom-workspace', 'tabletopsimulator-lua:gotoFunction': => @gotoFunction()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'tabletopsimulator-lua:jumpToFunction': => @jumpToCursorFunction()
     @subscriptions.add atom.commands.add 'atom-workspace', 'tabletopsimulator-lua:selectFunction': => @selectCurrentFunction()
     @subscriptions.add atom.commands.add 'atom-workspace', 'tabletopsimulator-lua:expandSelection': => @expandSelection()
     @subscriptions.add atom.commands.add 'atom-workspace', 'tabletopsimulator-lua:retractSelection': => @retractSelection()
@@ -493,6 +494,27 @@ module.exports = TabletopsimulatorLua =
       @functionListView = new FunctionListView().toggle(text)
     else
       @functionListView = new FunctionListView().toggle()
+
+  jumpToCursorFunction: ->
+    editor = atom.workspace.getActiveTextEditor()
+    if not editor or not editor.getPath().endsWith(".ttslua")
+      return
+    function_name = editor.getWordUnderCursor()
+    if not function_name or function_name == ''
+      return
+    lineCount = editor.getLineCount()
+    row = 0
+    while (row < lineCount)
+      line = editor.lineTextForBufferRow(row)
+      re = new RegExp('^\\s*function\\s+' + function_name)
+      m = line.match(re)
+      if m
+        editor.setCursorBufferPosition([row, 0])
+        return
+      row += 1
+    # If we didn't find it then open Go To Function panel
+    editor.selectWordsContainingCursors()
+    @gotoFunction()
 
   selectCurrentFunction: ->
     editor = atom.workspace.getActiveTextEditor()

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -570,20 +570,20 @@ module.exports = TabletopsimulatorLua =
         try
           filetext = fs.readFileSync(filepath, 'utf8')
         catch error
-          atom.notifications.addError(error.message, {icon: 'file-icon', detail: filepath})
+          atom.notifications.addError(error.message, {dismissable: true, icon: 'type-file', detail: filepath})
         if filetext
           if filepath of alreadyInserted
-            atom.notifications.addWarning(keyword + " used for same file twice.", {icon: 'file-icon', detail: filepath})
-            filetext = ''
+            atom.notifications.addWarning(keyword + " used for same file twice.", {dismissable: true, icon: 'type-file', detail: filepath})
+            lines[i] = ''
           else
             alreadyInserted[filepath] = true
             filetext = filetext.replace(/[\s\n\r]*$/, '')
-          if ignore_marker
-            marker = ''
-          else
-            marker = '----' + found[1]
-          newDir = path.dirname(filepath)
-          lines[i] = marker + '\n' + @insertFiles(filetext, keyword, newDir, alreadyInserted, true) + '\n' + marker
+            if ignore_marker
+              marker = ''
+            else
+              marker = '----' + found[1]
+            newDir = path.dirname(filepath)
+            lines[i] = marker + '\n' + @insertFiles(filetext, keyword, newDir, alreadyInserted, true) + '\n' + marker
     return lines.join('\n')
 
   excludeChange: (newValue) ->

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -141,7 +141,6 @@ class FileHandler
         else if stack.length == 0
           output.push(line)
       editor.setText(output.join('\n'))
-      console.log expandedLineNumbers
     # Replace \u character codes
     if atom.config.get('tabletopsimulator-lua.loadSave.convertUnicodeCharacters')
       replace_unicode = (unicode) ->

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -72,7 +72,9 @@ completeFilepath = (fn, dir) ->
   filepath = fn
   if not filepath.endsWith('.ttslua')
     filepath += '.ttslua'
-  if filepath.match(/^~[\\/]/) # home dir selector
+  if filepath.match(/^![\\/]/) # ! = configured dir for TTSLua files
+    filepath = path.join(getRootPath(), filepath[2..])
+  else if filepath.match(/^~[\\/]/) # ~ = home dir
     filepath = path.join(os.homedir(), filepath[2..])
   if os.platform() == 'win32'
     fullPathPattern = /\:/
@@ -260,7 +262,7 @@ module.exports = TabletopsimulatorLua =
           default: false
         includeOtherFilesPath:
           title: 'Experimental: Base path for files you wish to #include'
-          description: 'Start with ``~`` to represent your user folder.  If left blank will default to ``~' + PATH_SEPERATOR + 'Documents' + PATH_SEPERATOR + 'Tabletop Simulator' + PATH_SEPERATOR + '``'
+          description: 'Start with ``~`` to represent your user folder.  If left blank will default to ``~' + PATH_SEPERATOR + 'Documents' + PATH_SEPERATOR + 'Tabletop Simulator' + PATH_SEPERATOR + '``' + '.  You may refer to this path explicitly in your code by starting your #include path with ``!' + PATH_SEPERATOR + '``'
           order: 5
           type: 'string'
           default: ''

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -541,6 +541,13 @@ module.exports = TabletopsimulatorLua =
               fs.unlinkSync(@deletefile)
           catch error
 
+          # remove old name for temp dir, for people who have used previous versions (21/08/17)
+          # TODO remove this at some later date
+          oldttsLuaDir = path.join(os.tmpdir(), "TabletopSimulator", "Lua")
+          try
+            atom.project.removePath(oldttsLuaDir)
+          catch error
+          # Add temp dir to atom 
           atom.project.addPath(ttsLuaDir)
 
           if not TabletopsimulatorLua.if_connected

--- a/menus/tabletopsimulator-lua.cson
+++ b/menus/tabletopsimulator-lua.cson
@@ -11,7 +11,16 @@
         {
           label: 'Save And Play',
           command:'tabletopsimulator-lua:saveAndPlay'
-        }
+        },
+        {type: 'separator'},
+        {
+          'label': 'Go To Function'
+          'command': 'tabletopsimulator-lua:gotoFunction'
+        },
+        {
+          'label': 'Select Current Function'
+          'command': 'tabletopsimulator-lua:selectFunction'
+        },
       ]
     }
   ]
@@ -28,7 +37,16 @@
         {
           'label': 'Save And Play'
           'command': 'tabletopsimulator-lua:saveAndPlay'
-        }
+        },
+        {type: 'separator'},
+        {
+          'label': 'Go To Function'
+          'command': 'tabletopsimulator-lua:gotoFunction'
+        },
+        {
+          'label': 'Select Current Function'
+          'command': 'tabletopsimulator-lua:selectFunction'
+        },
       ]
     ]
   }

--- a/menus/tabletopsimulator-lua.cson
+++ b/menus/tabletopsimulator-lua.cson
@@ -21,6 +21,14 @@
           'label': 'Select Current Function'
           'command': 'tabletopsimulator-lua:selectFunction'
         },
+        {
+          'label': 'Block Expand Selection'
+          'command': 'tabletopsimulator-lua:expandSelection'
+        },
+        {
+          'label': 'Block Retract Selection'
+          'command': 'tabletopsimulator-lua:retractSelection'
+        },
       ]
     }
   ]
@@ -46,6 +54,14 @@
         {
           'label': 'Select Current Function'
           'command': 'tabletopsimulator-lua:selectFunction'
+        },
+        {
+          'label': 'Block Expand Selection'
+          'command': 'tabletopsimulator-lua:expandSelection'
+        },
+        {
+          'label': 'Block Retract Selection'
+          'command': 'tabletopsimulator-lua:retractSelection'
         },
       ]
     ]

--- a/menus/tabletopsimulator-lua.cson
+++ b/menus/tabletopsimulator-lua.cson
@@ -18,6 +18,11 @@
           'command': 'tabletopsimulator-lua:gotoFunction'
         },
         {
+          'label': 'Jump To Cursor Function'
+          'command': 'tabletopsimulator-lua:jumpToFunction'
+        },
+        {type: 'separator'},
+        {
           'label': 'Select Current Function'
           'command': 'tabletopsimulator-lua:selectFunction'
         },
@@ -55,6 +60,11 @@
           'label': 'Go To Function'
           'command': 'tabletopsimulator-lua:gotoFunction'
         },
+        {
+          'label': 'Jump To Cursor Function'
+          'command': 'tabletopsimulator-lua:jumpToFunction'
+        },
+        {type: 'separator'},
         {
           'label': 'Select Current Function'
           'command': 'tabletopsimulator-lua:selectFunction'

--- a/menus/tabletopsimulator-lua.cson
+++ b/menus/tabletopsimulator-lua.cson
@@ -23,6 +23,10 @@
         },
         {type: 'separator'},
         {
+          'label': 'Display Current Function Name'
+          'command': 'tabletopsimulator-lua:displayCurrentFunction'
+        },
+        {
           'label': 'Select Current Function'
           'command': 'tabletopsimulator-lua:selectFunction'
         },
@@ -65,6 +69,10 @@
           'command': 'tabletopsimulator-lua:jumpToFunction'
         },
         {type: 'separator'},
+        {
+          'label': 'Display Current Function Name'
+          'command': 'tabletopsimulator-lua:displayCurrentFunction'
+        },
         {
           'label': 'Select Current Function'
           'command': 'tabletopsimulator-lua:selectFunction'

--- a/menus/tabletopsimulator-lua.cson
+++ b/menus/tabletopsimulator-lua.cson
@@ -29,6 +29,10 @@
           'label': 'Block Retract Selection'
           'command': 'tabletopsimulator-lua:retractSelection'
         },
+        {
+          'label': 'Toggle Selection Cursor Position'
+          'command': 'tabletopsimulator-lua:toggleSelectionCursor'
+        },
       ]
     }
   ]
@@ -62,6 +66,10 @@
         {
           'label': 'Block Retract Selection'
           'command': 'tabletopsimulator-lua:retractSelection'
+        },
+        {
+          'label': 'Toggle Selection Cursor Position'
+          'command': 'tabletopsimulator-lua:toggleSelectionCursor'
         },
       ]
     ]

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     }
   },
   "dependencies": {
-    "mkdirp": "~0.3.5"
+    "mkdirp": "~0.3.5",
+    "space-pen": "^5.1.1",
+    "atom-space-pen-views": "^2.0.0"
   }
 }


### PR DESCRIPTION
**Added some commands to Atom:**

Goto Function (ctrl-g):
Lists all functions in program, user can filter by typing.  Hit enter or click to jump straight to function declaration.  Typing a number emulates Atom's Go To Line Number behaviour, so that keyboard shortcut can be overidden (i.e.  ctrl-g) .  Will also perform relative line-number jumps if number is prefixed with +/- (i.e. +10 will move cursor forward 10 rows)

Jump To Current Function (ctrl-shift-g):
As above, but directly from the function name the cursor is positioned on.

Select Function (ctrl-alt-<):
Same as shift-clicking the function name in the status bar; will select all the lines of the function the cursor is currently occupying.  Repeating the command will select the parent function, if applicable.

Expand Selection (ctrl-<):
Selects all the text in a code block around the cursor.  Hitting again will expand to the next block in the hierarchy.

Retract Selection (ctrl->):
Steps back down a block wrt the above commands.

Toggle Selection Cursor (ctrl-?):
Switches the cursor between the start and end of the selected text.

Display Current Function (ctrl-i):
Display name of function cursor is in with a popup notification.


**Additional suggestion snippet for coroutines:**
```function...coroutine...repeat...end``` will insert a coroutine with a repeat loop containing a yield.


**Implemented issue #25:**
Package setting to only open Global.-1.ttslua in atom when getting scripts from TTS (i.e. don't open scripts for all other objects).  Other scripts may still be opened manually from Project pane.  Renamed the Lua temp folder for clarity (from 'Lua' to 'Tabletop Simulator Lua')


**Experimental additions:**
Use at your own risk!

Re-open files from outwith the TTS folder:
Non-TTS files you had open will be reopened after you hit Save And Play.

Insert other files specified in source code:
Allows you to use more modular code by splitting your code up into different files.  Also allows you to keep your code in a more stable location than the TTS temp folder (handy for git/svn etc)

Base path for files you wish to #include:
Allows you to set which folder is looked in for #include statements.

