### PR TITLE
Post-update fixes

### DIFF
--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -459,11 +459,13 @@ module.exports = TabletopsimulatorLua =
         @doCatalog(editor.getText(), filepath, !isFromTTS(filepath))
       view = atom.views.getView(editor)
       f = () ->
-        atom.commands.dispatch(view, 'linter:lint')
-      delay = 0
-      while delay < 1000
-        delay += 100
-        setTimeout f, delay
+        atom.commands.dispatch(view, 'linter:toggle')
+      f()
+      setTimeout f, 1000
+      #delay = 0
+      #while delay < 1000
+      #  delay += 100
+      #  setTimeout f, delay
 
 
   onSave: (event) ->

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -457,15 +457,14 @@ module.exports = TabletopsimulatorLua =
     if filepath and filepath.endsWith('.ttslua')
       if not (filepath of @functionPaths)
         @doCatalog(editor.getText(), filepath, !isFromTTS(filepath))
-      view = atom.views.getView(editor)
-      f = () ->
-        atom.commands.dispatch(view, 'linter:toggle')
-      f()
-      setTimeout f, 1000
-      #delay = 0
-      #while delay < 1000
-      #  delay += 100
-      #  setTimeout f, delay
+      # TODO 2017-10-01 Below code to fix linter not seeing scopes on load.
+      #                 That problem seems to have fixed itself though?
+      #view = atom.views.getView(editor)
+      #atom.commands.dispatch(view, 'linter:toggle')
+      #f = () ->
+      #  atom.commands.dispatch(view, 'linter:toggle')
+      #  atom.commands.dispatch(view, 'linter:lint')
+      #setTimeout f, 1000
 
 
   onSave: (event) ->

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -267,6 +267,13 @@ module.exports = TabletopsimulatorLua =
           order: 5
           type: 'string'
           default: ''
+        delayLinter:
+          title: 'Delay Linter When Loading'
+          description: 'Delay in ``ms`` before linting a newly loaded file.'
+          order: 6
+          type: 'integer'
+          default: 0
+          minimum: 0
 #        includeKeyword:
 #          title: 'Insertion keyword to use'
 #          description: 'Example (using default keyword): ``-- include c:\\path\\to\\file`` will insert the contents of file ``c:\\path\\to\\file.ttslua``\nIf you specify a file with no path then it will look for the file in the same folder as the current file.'
@@ -457,14 +464,14 @@ module.exports = TabletopsimulatorLua =
     if filepath and filepath.endsWith('.ttslua')
       if not (filepath of @functionPaths)
         @doCatalog(editor.getText(), filepath, !isFromTTS(filepath))
-      # TODO 2017-10-01 Below code to fix linter not seeing scopes on load.
-      #                 That problem seems to have fixed itself though?
-      #view = atom.views.getView(editor)
-      #atom.commands.dispatch(view, 'linter:toggle')
-      #f = () ->
-      #  atom.commands.dispatch(view, 'linter:toggle')
-      #  atom.commands.dispatch(view, 'linter:lint')
-      #setTimeout f, 1000
+      linterDelay = atom.config.get('tabletopsimulator-lua.loadSave.delayLinter')
+      if linterDelay > 0
+        view = atom.views.getView(editor)
+        atom.commands.dispatch(view, 'linter:toggle')
+        f = () ->
+          atom.commands.dispatch(view, 'linter:toggle')
+          atom.commands.dispatch(view, 'linter:lint')
+        setTimeout f, linterDelay
 
 
   onSave: (event) ->

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -1243,6 +1243,7 @@ module.exports = TabletopsimulatorLua =
         filepath = editor.getPath()
         indents = [0]
         nextLineContinuation = false
+        overrideContinuation = false
         nextLineExpectIndent = null
         lints = []
         suppress = [false]
@@ -1335,11 +1336,12 @@ module.exports = TabletopsimulatorLua =
                     nextLineExpectIndent = null
             else if nextLineContinuation[1] == ','
               m = line.match(/^(\s*)([^\s]+)/)
-              if m and m[2].match(/^[\]\}\)]+$/)
+              if m and m[2].match(/^[\]\}\)]+/)
                 indent = m[1].length
                 [..., prevIndent, currentIndent] = indents
                 if indent == prevIndent
                   indents.pop()
+                  overrideContinuation = true
                 else
                   addLint('warning', 'Dedent does not match indent', i, indent)
                   while indent < currentIndent
@@ -1347,7 +1349,11 @@ module.exports = TabletopsimulatorLua =
                     [..., currentIndent] = indents
                   if indent > currentIndent
                     indents.push(indent)
-            nextLineContinuation = line.match(/(\sor|\sand|\.\.|,)\s*$/)
+            if overrideContinuation
+              nextLineContinuation = false
+              overrideContinuation = false
+            else
+              nextLineContinuation = line.match(/(\sor|\sand|\.\.|,)\s*$/)
           i += 1
         try
           luaparse.parse(editor.getText().replace(/^#include/gm, '--nclude'))

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -1243,7 +1243,9 @@ module.exports = TabletopsimulatorLua =
         nextLineContinuation = false
         nextLineExpectIndent = null
         lints = []
+        suppress = [false]
         addLint = (severity, message, row, column) ->
+          return if suppress[0]
           lints.push({
             severity: severity,
             excerpt: message,
@@ -1260,6 +1262,7 @@ module.exports = TabletopsimulatorLua =
         i = 0
         while (i < lineCount)
           line = editor.lineTextForBufferRow(i)
+          suppress[0] = line.endsWith('--') and not line.endsWith(']]--')
           scopes = editor.scopeDescriptorForBufferPosition([i, 0])
           if 'string.quoted.other.multiline.lua' in scopes.scopes
             i += 1
@@ -1344,5 +1347,6 @@ module.exports = TabletopsimulatorLua =
           row = error.line - 1
           column = error.column
           message = error.message
+          suppress[0] = false
           addLint('error', message, row, column)
         return lints

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -1231,6 +1231,7 @@ module.exports = TabletopsimulatorLua =
     console.log "Listening to #{domain}:#{serverport}"
     server.listen serverport, domain
 
+
   provideLinter: ->
     provider =
       name: 'TTS Lua'
@@ -1244,6 +1245,12 @@ module.exports = TabletopsimulatorLua =
         nextLineExpectIndent = null
         lints = []
         suppress = [false]
+        checkForError = (code) ->
+          try
+            luaparse.parse(code)
+          catch error
+            return error
+          return null
         addLint = (severity, message, row, column) ->
           return if suppress[0]
           lints.push({
@@ -1312,7 +1319,7 @@ module.exports = TabletopsimulatorLua =
                     irregular = "Dedent expected for '" + m[2] + "'"
               if irregular
                 addLint('warning', irregular, i, indent)
-              m = line.match(/^\s*(if|else|elseif|repeat|for|while|function)(\s|\(|$)(.*\send\s*$)?/)
+              m = line.match(/^\s*(if|else|elseif|repeat|for|while|function)(\s|\(|$)(.*\send[\s\)\}\]]*$)?/)
               if m and not m[3]
                 nextLineExpectIndent = m[1]
               else
@@ -1320,7 +1327,7 @@ module.exports = TabletopsimulatorLua =
                 if m and not m[1].endsWith('[[')
                   nextLineExpectIndent = m[1]
                 else
-                  m = line.match(/\s(function)(\s|\()(.*\send\s*$)?/)
+                  m = line.match(/\s(function)(\s|\()(.*\send[\s\)\]\}]*$)?/)
                   if m and not m[3]
                     nextLineExpectIndent = m[1]
                   else


### PR DESCRIPTION
Linter:
- Added ability to manually suppress a warning: postfix the line with --
- Added the option to delay the linter when a file is first opened
- Better understands one-liners (now works with closing parenthesis)
- Better understands table definitions (optional comma after last item)
- Fixed the linter spamming file locks when files are opened
