### PR TITLE
Go to line fixed, setting for automatically opening files, better runtime error reporting

### DIFF
--- a/keymaps/tabletopsimulator-lua.cson
+++ b/keymaps/tabletopsimulator-lua.cson
@@ -15,6 +15,7 @@
 'atom-workspace atom-text-editor:not([mini])':
   'ctrl-g':           'tabletopsimulator-lua:gotoFunction'
   'ctrl-shift-g':     'tabletopsimulator-lua:jumpToFunction'
+  'ctrl-e':           'tabletopsimulator-lua:gotoLastError'
   'ctrl-<':           'tabletopsimulator-lua:expandSelection'
   'ctrl->':           'tabletopsimulator-lua:retractSelection'
   'ctrl-alt-<':       'tabletopsimulator-lua:selectFunction'

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -176,7 +176,7 @@ class FileHandler
     # Map and remove included files
     if atom.config.get('tabletopsimulator-lua.loadSave.includeOtherFiles')
       text = editor.getText()
-      lines = text.split(/\r?\n/)
+      lines = text.split(/\n/)
       tree = fileMap[filepath] = {label: null, children: [], parent: null, startRow: 0, endRow: lines.length-1, depth: 0, closeTag: ''}
       output = []
       for line, row in lines
@@ -741,7 +741,7 @@ module.exports = TabletopsimulatorLua =
             lines[i] = ''
           else
             alreadyInserted[filepath] = true
-            filetext = filetext.replace(/[\s\n\r]*$/gm, '')
+            #filetext = filetext.replace(/[\s\n\r]*$/gm, '')
             marker = '----' + found[1]
             newDir = path.dirname(filepath)
             lines[i] = marker + '\n' + @insertFiles(filetext, newDir, alreadyInserted) + '\n' + marker

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -86,7 +86,7 @@ getRootPath = () ->
   return rootpath
 
 extractFileMap = (text, filepath) ->
-  lines = text.split(/\r?\n/)
+  lines = text.split(/\n/)
   tree = {label: filepath, children: [], parent: null, startRow: 0, endRow: lines.length-1, depth: 0}
   for line, row in lines
     found = line.match(insertedFileRegexp)
@@ -722,7 +722,7 @@ module.exports = TabletopsimulatorLua =
 
 
   insertFiles: (text, dir = null, alreadyInserted = {}) ->
-    lines = text.split(/\r?\n/)
+    lines = text.split(/\n/)
     for line, i in lines
       found = line.match(insertFileRegexp)
       if found
@@ -811,7 +811,7 @@ module.exports = TabletopsimulatorLua =
     @functionPaths[filepath] = {}
     otherFiles = {}
     stack = []
-    lines = text.split(/\r?\n/)
+    lines = text.split(/\n/)
     closingTag = []
     if not isFromTTS(filepath) and root == null
       root = path.dirname(filepath)

--- a/menus/tabletopsimulator-lua.cson
+++ b/menus/tabletopsimulator-lua.cson
@@ -21,6 +21,10 @@
           'label': 'Jump To Cursor Function'
           'command': 'tabletopsimulator-lua:jumpToFunction'
         },
+        {
+          'label': 'Jump To Last Error'
+          'command': 'tabletopsimulator-lua:gotoLastError'
+        },
         {type: 'separator'},
         {
           'label': 'Display Current Function Name'
@@ -67,6 +71,10 @@
         {
           'label': 'Jump To Cursor Function'
           'command': 'tabletopsimulator-lua:jumpToFunction'
+        },
+        {
+          'label': 'Jump To Last Error'
+          'command': 'tabletopsimulator-lua:gotoLastError'
         },
         {type: 'separator'},
         {


### PR DESCRIPTION
Fixed go to line function (was going to wrong line)

Removed all '\r?' regexp which were previously inserted as a pre-emptive fix; they just broke everything they touched (see: above bug)

Added more comprehensive setting to let user decide what files are opened in Atom when they are sent from TTS.  Can also completely disable communication with TTS.

Now displays a pop-up in Atom when your TTS mod hits a run-time error, with a button to jump to offending line (if able).  Also added ```Jump To Last Error``` menu option and hotkey ```ctrl-e```.

Changed some settings so they default to on for options which have proved stable (such as the unicode conversion setting)