### PR TITLE
v10.2 update

### DIFF
--- a/keymaps/tabletopsimulator-lua.cson
+++ b/keymaps/tabletopsimulator-lua.cson
@@ -24,3 +24,4 @@
   'ctrl-alt->':       'tabletopsimulator-lua:retractSelection'
   'ctrl-?':           'tabletopsimulator-lua:toggleSelectionCursor'
   'ctrl-i':           'tabletopsimulator-lua:displayCurrentFunction'
+  "ctrl-@":           'tabletopsimulator-lua:executeLuaSelection'

--- a/lib/checkbox-list-view.coffee
+++ b/lib/checkbox-list-view.coffee
@@ -1,0 +1,76 @@
+{$$, View} = require 'space-pen'
+{ScrollView} = require 'atom-space-pen-views'
+#CheckboxListView = require './checkbox-list-view'
+{CompositeDisposable} = require 'atom'
+
+module.exports = class CheckboxListView extends View
+
+  @content: (guids, editor) ->
+    tags = {}
+    for guid of guids
+      tags[guids[guid].tag] = true
+    @div class: 'checkbox-list-view', =>
+      @h1 'Generate GUID code'
+      @h2 'Select objects to include:'
+      @ul style: 'list-style-type: none; margin-top: 1em; margin-bottom: 1em;', =>
+        for tag of tags
+          @li =>
+            @label tag, class: 'input-label', =>
+              @input class: 'input-checkbox', alt: tag, type: 'checkbox', checked: true, change: 'onchange'
+      @div class: 'btn-group', =>
+        @button class: 'inline-block btn btn-primary checkbox-list-confirm', click: 'confirmedAsFunction', 'Generate Function'
+        @button class: 'inline-block btn btn-primary checkbox-list-confirm', click: 'confirmedAsCode', 'Generate Block'
+      @button class: 'inline-block btn checkbox-list-cancel', click: 'cancelled', 'Cancel'
+
+  initialize: (guids, editor) ->
+    @modalPanel = atom.workspace.addModalPanel(item: this, visible: false)
+    @guids = guids
+    @editor = editor
+    @pane = atom.workspace.paneForItem(@editor)
+    @doCancel = true
+    @tags = {}
+    for guid of guids
+      @tags[guids[guid].tag] = true
+      @doCancel = false
+
+  serialize: ->
+    checkboxListViewState: @checkboxListView.serialize()
+
+  onchange: (evt) ->
+    @tags[evt.target.alt] = evt.target.checked
+
+  confirmedAsFunction: ->
+    @function = true
+    @confirmed()
+
+  confirmedAsCode: ->
+    @function = false
+    @confirmed()
+
+  confirmed: ->
+    @confirmedCallback(@tags, @guids, @function)
+    @cancelled()
+
+  cancelled: ->
+    @destroy()
+    if @pane
+      @pane.activate()
+
+  toggle: (callback) ->
+    if @doCancel
+      atom.notifications.addInfo("No GUIDs found!")
+      @cancelled()
+    else
+      @confirmedCallback = callback
+      if @modalPanel.isVisible()
+        @modalPanel.hide()
+      else
+        @modalPanel.show()
+
+  # Returns an object that can be retrieved when package is activated
+  serialize: ->
+
+  # Tear down any state and detach
+  destroy: ->
+    @element.remove()
+    @modalPanel.destroy()

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -1417,6 +1417,14 @@ module.exports =
             descriptionMoreURL: 'http://berserk-games.com/knowledgebase/player/#getHoldingObjects'
           },
           {
+            snippet: 'getHoverObject()'
+            displayText: 'getHoverObject()'
+            type: 'function'
+            leftLabel: 'Table'
+            description: 'Returns the object that this player is hovering their pointer over.'
+            descriptionMoreURL: 'http://berserk-games.com/knowledgebase/player/#getHoverObject'
+          },
+          {
             snippet: 'getSelectedObjects()'
             displayText: 'getSelectedObjects()'
             type: 'function'
@@ -1577,6 +1585,82 @@ module.exports =
             leftLabel: 'bool'
             description: 'Destroys an existing timer.'
             descriptionMoreURL: 'http://berserk-games.com/knowledgebase/timer/#destroy'
+          },
+        ]
+
+      # Section: WebRequest Class
+      else if ((prefix == "." || scopeDescriptor.scopes[1] == "variable.other.lua") && previous_token == "WebRequest") || line.endsWith("WebRequest.") || (previous_token == "WebRequest" && this_token_intact)
+        suggestions = [
+          # Functions
+          {
+            snippet: 'get(${1:string|url}, ${2:Object|callback_owner}, ${3:string|callback})'
+            displayText: 'get(string url, Object callback_owner, string callback)'
+            type: 'function'
+            leftLabel: 'WebRequest'
+            description: 'Get data in text from the url. Callback function is supplied the WebRequest.'
+            descriptionMoreURL: 'http://berserk-games.com/knowledgebase/webrequest/#get'
+          },
+          {
+            snippet:
+              'get(${1:string|url}, ${2:Object|callback_owner}, ${3:string|callback}) -- returns and passes to callback:\n\t' +
+                '-- download_progress    bool      (0.0 - 1.0)\n\t' +
+                '-- error                string\n\t' +
+                '-- is_error             bool\n\t' +
+                '-- is_done              bool\n\t' +
+                '-- text                 string\n\t' +
+                '-- upload_progress      bool      (0.0 - 1.0)\n\t' +
+                '-- url                  string'
+            displayText: 'get(string url, Object callback_owner, string callback) -- returns ...'
+            type: 'function'
+            leftLabel: 'WebRequest'
+            description: 'Get data in text from the url. Callback function is supplied the WebRequest.'
+            descriptionMoreURL: 'http://berserk-games.com/knowledgebase/webrequest/#get'
+          },
+          {
+            snippet: 'post(${1:string|url}, ${2:Table|form}, ${3:Object|callback_owner}, ${4:string|callback})'
+            displayText: 'post(string url, Table form, Object callback_owner, string callback)'
+            type: 'function'
+            leftLabel: 'WebRequest'
+            description: 'Post the form to the url. Callback function is supplied the WebRequest.'
+            descriptionMoreURL: 'http://berserk-games.com/knowledgebase/webrequest/#post'
+          },
+          {
+            snippet: 'post(${1:string|url}, ${2:Table|form}, ${3:Object|callback_owner}, ${4:string|callback}) -- returns and passes to callback:\n\t' +
+              '-- download_progress    bool      (0.0 - 1.0)\n\t' +
+              '-- error                string\n\t' +
+              '-- is_error             bool\n\t' +
+              '-- is_done              bool\n\t' +
+              '-- text                 string\n\t' +
+              '-- upload_progress      bool      (0.0 - 1.0)\n\t' +
+              '-- url                  string'
+            displayText: 'post(string url, Table form, Object callback_owner, string callback) -- returns ...'
+            type: 'function'
+            leftLabel: 'WebRequest'
+            description: 'Post the form to the url. Callback function is supplied the WebRequest.'
+            descriptionMoreURL: 'http://berserk-games.com/knowledgebase/webrequest/#post'
+          },
+          {
+            snippet: 'pull(${1:string|url}, ${2:string|data}, ${3:Object|callback_owner}, ${4:string|callback})'
+            displayText: 'post(string url, string data, Object callback_owner, string callback)'
+            type: 'function'
+            leftLabel: 'WebRequest'
+            description: 'Put the data to the url. Callback function is supplied the WebRequest.'
+            descriptionMoreURL: 'http://berserk-games.com/knowledgebase/webrequest/#pull'
+          },
+          {
+            snippet: 'pull(${1:string|url}, ${2:string|data}, ${3:Object|callback_owner}, ${4:string|callback}) -- returns and passes to callback:\n\t' +
+              '-- download_progress    bool      (0.0 - 1.0)\n\t' +
+              '-- error                string\n\t' +
+              '-- is_error             bool\n\t' +
+              '-- is_done              bool\n\t' +
+              '-- text                 string\n\t' +
+              '-- upload_progress      bool      (0.0 - 1.0)\n\t' +
+              '-- url                  string'
+            displayText: 'post(string url, string data, Object callback_owner, string callback) -- returns ...'
+            type: 'function'
+            leftLabel: 'WebRequest'
+            description: 'Put the data to the url. Callback function is supplied the WebRequest.'
+            descriptionMoreURL: 'http://berserk-games.com/knowledgebase/webrequest/#pull'
           },
         ]
 
@@ -2785,12 +2869,13 @@ module.exports =
               'callback       = ${3:-- string},\n\t' +
               'callback_owner = ${4:-- Object},\n\t' +
               'params         = ${5:-- Table},\n\t' +
-              'flip           = ${6:-- bool},\n\t' +
-              'guid           = ${7:-- string},\n\t' +
-              'index          = ${8:-- int},\n\t' +
-              'top            = ${9:-- bool [true]},\n' +
+              'smooth         = ${6:-- bool},\n\t' +
+              'flip           = ${7:-- bool},\n\t' +
+              'guid           = ${8:-- string},\n\t' +
+              'index          = ${9:-- int},\n\t' +
+              'top            = ${10:-- bool [true]},\n' +
               '})'
-            displayText: 'takeObject({Vector position, Vector rotation, string callback, Object callback_owner, Table params, bool flip, string guid, int index, bool top})'
+            displayText: 'takeObject({Vector position, Vector rotation, string callback, Object callback_owner, Table params, bool smooth, bool flip, string guid, int index, bool top})'
             type: 'function'
             leftLabel: 'Object'
             description: 'Takes an Object from this container.'
@@ -2879,6 +2964,14 @@ module.exports =
             type: 'function'
             description: 'This function is called every time a player sends a chat message.  Return false to cancel that message.'
             descriptionMoreURL: 'http://berserk-games.com/knowledgebase/api/#onChat'
+          },
+          {
+            snippet: 'onExternalMessage(table)\n\t${0:-- body...}\nend'
+            displayText: 'onExternalMessage(Table table)'
+            type: 'function'
+            leftLabel: 'bool'
+            description: 'This function called when a message is received from the External Editor API.'
+            descriptionMoreURL: 'http://berserk-games.com/knowledgebase/external-editor-api/'
           },
           {
             snippet: 'onFixedUpdate()\n\t${0:-- body...}\nend'
@@ -3103,6 +3196,13 @@ module.exports =
             description: 'The Timer class.'
             descriptionMoreURL: 'http://berserk-games.com/knowledgebase/timer/'
           },
+          {
+            snippet: 'WebRequest'
+            displayText: 'WebRequest'
+            type: 'constant'
+            description: 'The WebRequest class.'
+            descriptionMoreURL: 'http://berserk-games.com/knowledgebase/webrequest/'
+          },
           # Global Management Functions
           {
             snippet: 'addNotebookTab(${1:Table|parameters})'
@@ -3303,6 +3403,14 @@ module.exports =
             descriptionMoreURL: 'http://berserk-games.com/knowledgebase/api/#removeNotebookTab'
           },
           {
+            snippet: 'sendExternalMessage(${1:Table|table})'
+            displayText: 'sendExternalMessage(Table table)'
+            type: 'function'
+            leftLabel: 'bool'
+            description: 'Sends table to whatever is connected to the External Editor API.'
+            descriptionMoreURL: 'http://berserk-games.com/knowledgebase/external-editor-api/'
+          },
+          {
             snippet: 'setNotes(${1:string|notes})'
             displayText: 'setNotes(string notes)'
             type: 'function'
@@ -3327,10 +3435,11 @@ module.exports =
               'scale          = ${4:-- Vector [x=1, y=1, z=1]},\n\t' +
               'callback       = ${5:-- string},\n\t' +
               'callback_owner = ${6:-- Object},\n\t' +
-              'params         = ${7:-- Table},\n\t' +
-              'snap_to_grid   = ${8:-- bool},\n' +
+              'sound          = ${7:-- Object},\n\t' +
+              'params         = ${8:-- Table},\n\t' +
+              'snap_to_grid   = ${9:-- bool},\n' +
               '})'
-            displayText: 'spawnObject({string type, Vector position, Vector rotation, Vector scale, string callback, Object callback_owner, Table params, bool snap_to_grid})'
+            displayText: 'spawnObject({string type, Vector position, Vector rotation, Vector scale, string callback, Object callback_owner, bool sound, Table params, bool snap_to_grid})'
             type: 'function'
             leftLabel: 'Object'
             description: 'Spawns an Object and returns a reference to it.'

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -1397,6 +1397,9 @@ module.exports = TabletopsimulatorLua =
           scopes = editor.scopeDescriptorForBufferPosition([i, line.length])
           if 'comment.line.double-dash.lua' in scopes.scopes
             line = line.split('--')[0]
+            if line.match(/^\s*$/)
+              i += 1
+              continue
           m = line.match(/^(\s*)([^\s]+)/)
           if m
             indent = m[1].length

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -429,7 +429,7 @@ module.exports = TabletopsimulatorLua =
           description: "When automatically generating GUID code, format the variable name like this.  Can use ``(Field)`` ``(field)`` or ``(FIELD)``to refer to object properties, ``(FIELD:#)`` to limit to ``#`` characters, ``(FIELD?xxx:yyy)`` to insert ``xxx`` if FIELD is present and ``yyy`` if it's not.  Fields: ``Name`` ``Nickname`` ``Description`` ``Tooltip``.  ``[from:to]`` will replace ``from`` with ``to``"
           order: 4
           type: 'string'
-          default: '(name)_(nickname:12)[die_:d][scriptingtrigger:zone]'
+          default: '(name)_(nickname:12)[die_:d][scriptingtrigger:zone][custom_:][game_piece_:][infinite_:][fogofwartrigger:hidden]'
     editor:
       title: 'Editor'
       order: 4
@@ -676,7 +676,7 @@ module.exports = TabletopsimulatorLua =
           guid = guid.substring(1, 7)
           if guid of @guids
             duration = 3
-            if @guids[guid].Name == "ScriptingTrigger"
+            if @guids[guid].Name.indexOf("Trigger") != -1
               transform = @guids[guid].Transform
               @executeLua("""
                   Physics.cast({
@@ -688,6 +688,7 @@ module.exports = TabletopsimulatorLua =
                     max_distance = 30,
                     debug        = true,
                   })
+                  if __atom_highlight_guids ~= nil then __atom_highlight_guids.end_time = 0 end
                 """, false)
             else
               @executeLua("""
@@ -1287,7 +1288,7 @@ module.exports = TabletopsimulatorLua =
         [f, t] = s.split(':', 2)
         replacements[f] = t
         return ''
-      format = format.replace(/\[[^\]:]+:[^\]:]+\]/g, get_replacements)
+      format = format.replace(/\[[^\]:]+:[^\]:]*\]/g, get_replacements)
       formats = {}
       for field in fields
         formats[field] = {field: field, f: (s) -> s}

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -872,11 +872,15 @@ module.exports = TabletopsimulatorLua =
               # Insert included files
               if atom.config.get('tabletopsimulator-lua.loadSave.includeOtherFiles')
                 @luaObject.script = @insertFiles(@luaObject.script)
+              # TODO this section commented out because TTS now handles unicode correctly
+              # When setting is enabled we still convert \u codes to utf8 when loading
+              # but we no longer write \u codes to TTS.
+              # This setting should be removed entirely at a future date
+              #if atom.config.get('tabletopsimulator-lua.loadSave.convertUnicodeCharacters')
               # Replace with \u character codes
-              if atom.config.get('tabletopsimulator-lua.loadSave.convertUnicodeCharacters')
-                replace_character = (character) ->
-                  return "\\u{" + character.codePointAt(0).toString(16) + "}"
-                @luaObject.script = @luaObject.script.replace(/[\u0080-\uFFFF]/g, replace_character)
+              #  replace_character = (character) ->
+              #    return "\\u{" + character.codePointAt(0).toString(16) + "}"
+              #  @luaObject.script = @luaObject.script.replace(/[\u0080-\uFFFF]/g, replace_character)
               @luaObjects.scriptStates.push(@luaObject)
 
           console.log "Connected:", @if_connected

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -1348,26 +1348,26 @@ module.exports = TabletopsimulatorLua =
       editor.insertText(s, {select: true})
     @checkboxList = new CheckboxList(@guids, editor).toggle(insert)
 
-  parseSaveState: (cls, saveState) ->
-    cls.saveState = saveState
-    cls.guids = {}
+  parseSaveState: (self, saveState) ->
+    self.saveState = saveState
+    self.guids = {}
     walkSaveState = (node, parent) ->
       nodes = []
       guid = parent
       for k of node
         if k == 'GUID'
           guid = node[k]
-          cls.guids[guid] = {parent: parent, tag: node.Name, Name: node.Name, Nickname: node.Nickname, Description: node.Description, Transform: node.Transform, Tooltip: node.Tooltip}
+          self.guids[guid] = {parent: parent, tag: node.Name, Name: node.Name, Nickname: node.Nickname, Description: node.Description, Transform: node.Transform, Tooltip: node.Tooltip}
         else if typeof node[k] == 'object'
           nodes.push(k)
       for k in nodes
         walkSaveState(node[k], guid)
     walkSaveState(saveState, null)
 
-  handleMessage: (cls, data, fromTTS = false) ->
+  handleMessage: (self, data, fromTTS = false) ->
     id = data.messageID
     if data.saveState and data.saveState != undefined
-      cls.parseSaveState(cls, data.saveState)
+      self.parseSaveState(self, data.saveState)
 
     if id == TTS_MSG_NONE
       return
@@ -1457,7 +1457,7 @@ module.exports = TabletopsimulatorLua =
       @stopConnection()
 
     handleMessage = @handleMessage
-    cls = this
+    self = this
 
     @connection = net.createConnection clientport, domain
     @connection.tabletopsimulator = @
@@ -1475,7 +1475,7 @@ module.exports = TabletopsimulatorLua =
         @data = JSON.parse(@data_cache)
       catch error
         return
-      handleMessage(cls, @data)
+      handleMessage(self, @data)
       @data_cache = ""
 
     @connection.on 'error', (e) ->
@@ -1495,7 +1495,7 @@ module.exports = TabletopsimulatorLua =
     if atom.config.get('tabletopsimulator-lua.loadSave.communicationMode') == 'disable'
       return
     handleMessage = @handleMessage
-    cls = this
+    self = this
     server = net.createServer (socket) ->
       #console.log "New connection from #{socket.remoteAddress}"
       socket.data_cache = ""
@@ -1508,7 +1508,7 @@ module.exports = TabletopsimulatorLua =
           @data = JSON.parse(@data_cache)
         catch error
           return
-        handleMessage(cls, @data, true)
+        handleMessage(self, @data, true)
         @data_cache = ""
 
       socket.on 'error', (e) ->

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -1326,12 +1326,7 @@ module.exports = TabletopsimulatorLua =
     console.log "Sending test message..."
     if not TabletopsimulatorLua.if_connected
       TabletopsimulatorLua.startConnection()
-    msg = JSON.stringify({messageID: ATOM_MSG_LUA, guid: '-1', script: """
-    print(dice.d4.getValue())
-    print("")
-    print("")
-    """})
-    #TabletopsimulatorLua.connection.write '{ messageID: ' + ATOM_MSG_CUSTOM + ' , customMessage: {test: 1, foo: "bar" }}'
+    msg = JSON.stringify({messageID: ATOM_MSG_CUSTOM, customMessage: {test: 1, foo: "bar" }})
     TabletopsimulatorLua.connection.write msg
 
   executeLua: (lua) ->

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -822,6 +822,7 @@ module.exports = TabletopsimulatorLua =
       detailedMessage: 'This will erase any local changes that you may have done.'
       buttons:
         Yes: ->
+          console.log "Request at", Date.now()
           destroyTTSEditors()
 
           # Delete any existing cached Lua files
@@ -1372,12 +1373,16 @@ module.exports = TabletopsimulatorLua =
       return
 
     else if id == TTS_MSG_NEW_OBJECTS
+      console.log "Received data from TTS", Date.now()
       readFilesFromTTS(data.scriptStates, fromTTS)
+      console.log "Finished receiving data from TTS", Date.now()
 
     else if id == TTS_MSG_NEW_GAME
+      console.log "Received data from TTS", Date.now()
       destroyTTSEditors()
       deleteCachedFiles()
       readFilesFromTTS(data.scriptStates)
+      console.log "Finished receiving data from TTS", Date.now()
       mutex.doingSaveAndPlay = false
 
     else if id == TTS_MSG_PRINT
@@ -1464,17 +1469,13 @@ module.exports = TabletopsimulatorLua =
       #console.log "Opened connection to #{domain}:#{clientport}"
 
     @connection.on 'data', (data) ->
-      # getObjects results in this
+      #console.log "Data received", Date.now()
+      @data_cache += data
       try
-        @data = JSON.parse(@data_cache + data)
+        @data = JSON.parse(@data_cache)
       catch error
-        @data_cache = @data_cache + data
-        #console.log "Received data cache"
         return
-      #console.log "Received: ", @data.messageID
-
       handleMessage(cls, @data)
-
       @data_cache = ""
 
     @connection.on 'error', (e) ->
@@ -1501,18 +1502,13 @@ module.exports = TabletopsimulatorLua =
       #socket.parse_line = @parse_line
 
       socket.on 'data', (data) ->
-        # saveAndPlay and making a new script in TTS results in this
-
+        #console.log "Data received", Date.now()
+        @data_cache += data
         try
-          @data = JSON.parse(@data_cache + data)
+          @data = JSON.parse(@data_cache)
         catch error
-          @data_cache = @data_cache + data
-          #console.log "Received data cache"
           return
-        #console.log "Received: #{@data.messageID} from #{socket.remoteAddress}"
-
         handleMessage(cls, @data, true)
-
         @data_cache = ""
 
       socket.on 'error', (e) ->

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -1390,13 +1390,14 @@ module.exports = TabletopsimulatorLua =
         while (i < lineCount)
           line = editor.lineTextForBufferRow(i)
           suppress[0] = line.endsWith('--') and not line.endsWith(']]--')
-          scopes = editor.scopeDescriptorForBufferPosition([i, 0])
-          if 'string.quoted.other.multiline.lua' in scopes.scopes
+          if 'string.quoted.other.multiline.lua' in editor.scopeDescriptorForBufferPosition([i, 0]).scopes
             i += 1
             continue
-          scopes = editor.scopeDescriptorForBufferPosition([i, line.length])
-          if 'comment.line.double-dash.lua' in scopes.scopes
-            line = line.split('--')[0]
+          if 'comment.line.double-dash.lua' in editor.scopeDescriptorForBufferPosition([i, line.length]).scopes
+            c = line.length - 1
+            while c > 0 and 'comment.line.double-dash.lua' in editor.scopeDescriptorForBufferPosition([i, c]).scopes
+              c -= 1
+            line = line.slice(0, c)
             if line.match(/^\s*$/)
               i += 1
               continue

--- a/menus/tabletopsimulator-lua.cson
+++ b/menus/tabletopsimulator-lua.cson
@@ -48,6 +48,11 @@
         },
         {type: 'separator'},
         {
+          'label': 'Execute Selected Lua'
+          'command': 'tabletopsimulator-lua:executeLuaSelection'
+        },
+        {type: 'separator'},
+        {
           'label': 'Generate GUID Code...'
           'command': 'tabletopsimulator-lua:generateGUIDFunction'
         },
@@ -106,6 +111,11 @@
         {
           'label': 'Toggle Selection Cursor Position'
           'command': 'tabletopsimulator-lua:toggleSelectionCursor'
+        },
+        {type: 'separator'},
+        {
+          'label': 'Execute Selected Lua'
+          'command': 'tabletopsimulator-lua:executeLuaSelection'
         },
         {type: 'separator'},
         {

--- a/menus/tabletopsimulator-lua.cson
+++ b/menus/tabletopsimulator-lua.cson
@@ -48,8 +48,18 @@
         },
         {type: 'separator'},
         {
+          'label': 'Generate GUID Code...'
+          'command': 'tabletopsimulator-lua:generateGUIDFunction'
+        },
+        {type: 'separator'},
+        {
           'label': 'Help'
           'command': 'tabletopsimulator-lua:openHelp'
+        },
+        {type: 'separator'},
+        {
+          'label': 'Test'
+          'command': 'tabletopsimulator-lua:test'
         },
       ]
     }
@@ -101,6 +111,11 @@
         {
           'label': 'Toggle Selection Cursor Position'
           'command': 'tabletopsimulator-lua:toggleSelectionCursor'
+        },
+        {type: 'separator'},
+        {
+          'label': 'Generate GUID Code...'
+          'command': 'tabletopsimulator-lua:generateGUIDFunction'
         },
         {type: 'separator'},
         {

--- a/menus/tabletopsimulator-lua.cson
+++ b/menus/tabletopsimulator-lua.cson
@@ -14,6 +14,11 @@
         },
         {type: 'separator'},
         {
+          'label': 'Open Save File'
+          'command': 'tabletopsimulator-lua:openSaveFile'
+        },
+        {type: 'separator'},
+        {
           'label': 'Go To Function'
           'command': 'tabletopsimulator-lua:gotoFunction'
         },
@@ -77,6 +82,11 @@
         {
           'label': 'Save And Play'
           'command': 'tabletopsimulator-lua:saveAndPlay'
+        },
+        {type: 'separator'},
+        {
+          'label': 'Open Save File'
+          'command': 'tabletopsimulator-lua:openSaveFile'
         },
         {type: 'separator'},
         {

--- a/menus/tabletopsimulator-lua.cson
+++ b/menus/tabletopsimulator-lua.cson
@@ -56,11 +56,6 @@
           'label': 'Help'
           'command': 'tabletopsimulator-lua:openHelp'
         },
-        {type: 'separator'},
-        {
-          'label': 'Test'
-          'command': 'tabletopsimulator-lua:test'
-        },
       ]
     }
   ]


### PR DESCRIPTION
- TTS now fully supports utf-8, so plugin no longer converts utf-8 to \u codes (it still does the reverse if the setting is enabled)
- Open Save File command
- Generate GUID Code command (pulls GUIDs from TTS save file and makes Lua for them).  Format customizable in Style section of package settings.
- Execute Selected Lua (ctrl-@) - send whatever code you have selected to TTS.  If you're in an object script will execute under that object, otherwise will execute in Global.
- Highlight GUID Objects setting.  When enabled and your cursor is near a GUID string will make TTS highlight the related object.
- Updated autocomplete suggestions for v10.2 additions
- Fixed some linter warnings relating to comments 